### PR TITLE
Implement journey distance feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Taisteala
 
-A CLI-based travel planner. This initial version downloads and parses the OpenFlights airports dataset.
+A CLI-based travel planner. This version can download airport data and
+calculate the distance for a multi-leg journey.
+
+## Usage
+
+- **Load airports data**
+
+  ```bash
+  python -m src.cli.main load-airports --dest data/airports.dat
+  ```
+
+- **Calculate journey distance**
+
+  ```bash
+  python -m src.cli.main journey JFK-LHR-SIN --dest data/airports.dat
+  ```

--- a/src/app/journey.py
+++ b/src/app/journey.py
@@ -1,0 +1,46 @@
+"""Journey distance calculations."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from src.utils.geo import great_circle_distance
+
+
+AirportsIndex = Dict[str, Dict[str, str]]
+
+
+def build_iata_index(airports: List[Dict[str, str]]) -> AirportsIndex:
+    """Build a mapping from IATA code to airport record."""
+    return {a["iata"]: a for a in airports if a.get("iata")}
+
+
+def calculate_journey(
+    codes: List[str], index: AirportsIndex
+) -> Tuple[List[float], float]:
+    """Calculate leg distances and total journey distance.
+
+    Args:
+        codes: Sequence of IATA codes. Must contain at least two codes.
+        index: Mapping of IATA code to airport info.
+
+    Returns:
+        Tuple of list of leg distances and total distance in kilometers.
+    """
+    if len(codes) < 2:
+        raise ValueError("Journey must include at least two airports")
+
+    legs: List[float] = []
+    for a, b in zip(codes, codes[1:]):
+        try:
+            a_data = index[a]
+            b_data = index[b]
+        except KeyError as exc:
+            raise KeyError(f"Unknown IATA code: {exc.args[0]}") from exc
+
+        lat1, lon1 = float(a_data["latitude"]), float(a_data["longitude"])
+        lat2, lon2 = float(b_data["latitude"]), float(b_data["longitude"])
+        legs.append(great_circle_distance(lat1, lon1, lat2, lon2))
+
+    total = sum(legs)
+    return legs, total

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -6,13 +6,23 @@ import argparse
 from pathlib import Path
 
 from src.utils.data import download_airports_data, load_airports
+from src.app.journey import build_iata_index, calculate_journey
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Taisteala CLI")
-    parser.add_argument("command", choices=["load-airports"], help="Command to execute")
     parser.add_argument(
-        "--dest", default="data/airports.dat", help="Path to store airports data"
+        "command", choices=["load-airports", "journey"], help="Command to execute"
+    )
+    parser.add_argument(
+        "journey",
+        nargs="?",
+        help="Dash-separated IATA codes for the journey (e.g. JFK-LHR-SIN)",
+    )
+    parser.add_argument(
+        "--dest",
+        default="data/airports.dat",
+        help="Path to airports data file",
     )
     return parser.parse_args(argv)
 
@@ -24,6 +34,16 @@ def main(argv: list[str] | None = None) -> None:
         download_airports_data(dest)
         airports = load_airports(dest)
         print(f"Loaded {len(airports)} airports")
+    elif args.command == "journey":
+        if not args.journey:
+            raise SystemExit("Journey string is required")
+        airports = load_airports(dest)
+        index = build_iata_index(airports)
+        codes = args.journey.split("-")
+        legs, total = calculate_journey(codes, index)
+        for i, dist in enumerate(legs, start=1):
+            print(f"Leg {i}: {dist:.2f} km")
+        print(f"Total: {total:.2f} km")
 
 
 if __name__ == "__main__":

--- a/src/utils/geo.py
+++ b/src/utils/geo.py
@@ -1,0 +1,30 @@
+"""Geographic calculations utilities."""
+
+from __future__ import annotations
+
+import math
+
+EARTH_RADIUS_KM = 6371.0
+
+
+def great_circle_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Calculate great circle distance between two points.
+
+    Args:
+        lat1: Latitude of first point in decimal degrees.
+        lon1: Longitude of first point in decimal degrees.
+        lat2: Latitude of second point in decimal degrees.
+        lon2: Longitude of second point in decimal degrees.
+
+    Returns:
+        Distance in kilometers.
+    """
+    lat1_rad, lon1_rad, lat2_rad, lon2_rad = map(math.radians, (lat1, lon1, lat2, lon2))
+    dlat = lat2_rad - lat1_rad
+    dlon = lon2_rad - lon1_rad
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2) ** 2
+    )
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return EARTH_RADIUS_KM * c

--- a/tests/fixtures/airports_three.dat
+++ b/tests/fixtures/airports_three.dat
@@ -1,0 +1,3 @@
+1,"Goroka Airport","Goroka","Papua New Guinea","GKA","AYGA",-6.081689834590001,145.391998291,5282,10,"U","Pacific/Port_Moresby","airport","OurAirports"
+2,"Madang Airport","Madang","Papua New Guinea","MAG","AYMD",-5.20707988739,145.789001465,20,10,"U","Pacific/Port_Moresby","airport","OurAirports"
+3,"Mount Hagen Kagamuga Airport","Mount Hagen","Papua New Guinea","HGU","AYMH",-5.826789855957031,144.29600524902344,5388,10,"U","Pacific/Port_Moresby","airport","OurAirports"

--- a/tests/test_journey.py
+++ b/tests/test_journey.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest  # noqa: E402
+from src.utils import data  # noqa: E402
+from src.app import journey as j  # noqa: E402
+
+
+@pytest.fixture
+def airports_three_path(tmp_path: Path) -> Path:
+    path = tmp_path / "airports.dat"
+    sample = Path("tests/fixtures/airports_three.dat").read_bytes()
+    path.write_bytes(sample)
+    return path
+
+
+def test_calculate_journey(airports_three_path: Path) -> None:
+    airports = data.load_airports(airports_three_path)
+    index = j.build_iata_index(airports)
+    codes = ["GKA", "MAG", "HGU"]
+    legs, total = j.calculate_journey(codes, index)
+    assert len(legs) == 2
+    assert legs[0] == pytest.approx(106.7139, rel=1e-4)
+    assert legs[1] == pytest.approx(179.0360, rel=1e-4)
+    assert total == pytest.approx(sum(legs))


### PR DESCRIPTION
## Summary
- add geographic utilities for great circle distance
- support calculating journey distances between airports
- extend CLI with `journey` command
- document the new feature in README
- cover journey distance logic with tests

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68738e1aeb44832f881c491ef93c9e50